### PR TITLE
Add faster agent polling and fixed pruning 

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ docker run -d \
 
 If the `AGENT_AUTO_REGISTER_*` variables are provided (we recommend that you do), then the agent will be automatically approved by the server. See the [auto registration docs](https://docs.gocd.org/20.2.0/advanced_usage/agent_auto_register.html) on the GoCD website.
 
+## Fast polling
+
+```
+docker run -d -e AGENT_FAST_POLLING=1 kudulab/gocd-agent
+```
+
+If the `AGENT_FAST_POLLING` variable is set to anything at all, the agent will poll the server for work much more frequently than the default settings. For use with a small agent fleet.
+
 ## Configuring SSL
 
 To configure SSL parameters, pass the parameters using the environment variable `AGENT_BOOTSTRAPPER_ARGS`. See [this documentation](https://docs.gocd.org/20.2.0/installation/ssl_tls/end_to_end_transport_security.html) for supported options.

--- a/image/docker-gc.sh
+++ b/image/docker-gc.sh
@@ -2,4 +2,4 @@
 
 docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v /etc:/etc:ro -e MINIMUM_IMAGES_TO_SAVE=3 -e FORCE_IMAGE_REMOVAL=1 spotify/docker-gc
 
-docker system prune -af
+docker system prune -af --volumes

--- a/image/docker-gc.sh
+++ b/image/docker-gc.sh
@@ -2,5 +2,4 @@
 
 docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock -v /etc:/etc:ro -e MINIMUM_IMAGES_TO_SAVE=3 -e FORCE_IMAGE_REMOVAL=1 spotify/docker-gc
 
-docker volume prune -f
-docker image prune -af
+docker system prune -af

--- a/image/services.d/go-agent/run
+++ b/image/services.d/go-agent/run
@@ -59,6 +59,16 @@ setup_autoregister_properties_file() {
   fi
 }
 
+setup_poll_timing() {
+  sed -i $3 "/$1=/d"
+  echo "$1=$2" >> $3
+}
+
+setup_fast_poll_timings() {
+  setup_poll_timing agent.get.work.interval 1000 $1
+  setup_poll_timing agent.instruction.interval 1500 $1
+}
+
 AGENT_WORK_DIR="/go"
 GOCD_HOME="/home/go"
 
@@ -109,6 +119,11 @@ if [ "$1" = "${AGENT_WORK_DIR}/bin/go-agent" ]; then
   fi
 
   setup_autoregister_properties_file "${AGENT_WORK_DIR}/config/autoregister.properties"
+
+  # assuming a small agent fleet, poll more regularly for work
+  if [ ! -z "${AGENT_FAST_POLLING}" ]; then
+    setup_fast_poll_timings "${AGENT_WORK_DIR}/agent.properties"
+  fi
 
   yell "Running custom scripts in /docker-entrypoint.d/ ..."
 


### PR DESCRIPTION
Fast agent polling is enableable using an environment flag.
Pruning now removes all volumes as well as everything else, on the hour, every hour the agent is up.